### PR TITLE
add guard for asset compilation. finishes #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 .DS_STORE
+.sass-cache
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+gem 'guard'
+gem 'guard-jekyll-plus'
+gem 'guard-coffeescript'
+gem 'guard-sass'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,81 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    classifier (1.3.3)
+      fast-stemmer (>= 1.0.0)
+    coderay (1.0.9)
+    coffee-script (2.2.0)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.6.3)
+    colorator (0.1)
+    commander (4.1.5)
+      highline (~> 1.6.11)
+    directory_watcher (1.4.1)
+    execjs (2.0.2)
+    fast-stemmer (1.0.2)
+    ffi (1.9.0)
+    formatador (0.2.4)
+    guard (1.8.2)
+      formatador (>= 0.2.4)
+      listen (>= 1.0.0)
+      lumberjack (>= 1.0.2)
+      pry (>= 0.9.10)
+      thor (>= 0.14.6)
+    guard-coffeescript (1.3.4)
+      coffee-script (>= 2.2.0)
+      guard (>= 1.1.0)
+    guard-jekyll-plus (1.4.9)
+      guard (>= 1.1.0)
+      jekyll (>= 1.0.0)
+    guard-sass (1.3.2)
+      guard (>= 1.1.0)
+      sass (>= 3.1)
+    highline (1.6.19)
+    jekyll (1.2.1)
+      classifier (~> 1.3)
+      colorator (~> 0.1)
+      commander (~> 4.1.3)
+      directory_watcher (~> 1.4.1)
+      liquid (~> 2.5.2)
+      maruku (~> 0.5)
+      pygments.rb (~> 0.5.0)
+      redcarpet (~> 2.3.0)
+      safe_yaml (~> 0.7.0)
+    liquid (2.5.3)
+    listen (1.3.0)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      rb-kqueue (>= 0.2)
+    lumberjack (1.0.4)
+    maruku (0.7.0)
+    method_source (0.8.1)
+    posix-spawn (0.3.6)
+    pry (0.9.12.2)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    pygments.rb (0.5.2)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
+    rb-fsevent (0.9.3)
+    rb-inotify (0.9.1)
+      ffi (>= 0.5.0)
+    rb-kqueue (0.2.0)
+      ffi (>= 0.5.0)
+    redcarpet (2.3.0)
+    safe_yaml (0.7.1)
+    sass (3.2.12)
+    slop (3.4.5)
+    thor (0.18.1)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  guard
+  guard-coffeescript
+  guard-jekyll-plus
+  guard-sass
+  jekyll

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,12 @@
+# More info at https://github.com/guard/guard#readme
+
+notification :off
+
+guard "jekyll-plus", :serve => true, :baseurl => '/' do
+  watch /.*/
+  ignore /^_site/
+end
+
+guard "coffeescript", :input => '_coffee', :output => 'js',  :all_on_start => true
+guard 'sass',         :input => '_scss',   :output => 'css', :all_on_start => true
+

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A fun, elegant game to see how many countries you can name.
 ## contributing
 
 * fork and clone the repo
-* `gem install jekyll`
-* `jekyll serve --watch --baseurl /`
+* `bundle install`
+* head's up: [one gem](https://github.com/guard/guard-coffeescript#javascript-runtimes) depends on you having a javascript runtime such as node on your system
+* `bundle exec guard`
 * visit <http://localhost:4000> and check it out
 * find or open [an issue](https://github.com/maxjacobson/mapquest/issues)
 * start hacking

--- a/_coffee/app.coffee
+++ b/_coffee/app.coffee
@@ -1,0 +1,3 @@
+$ ->
+  console.log "page ready"
+

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,13 @@
+# our site configuration
+
 title: mapquest!
 baseurl: http://maxjacobson.github.io/mapquest/
 
+# otherwise http://maxjacobson.github.io/mapquest/Gemfile would be included in the generated site
+exclude:
+- LICENSE
+- README.md
+- Gemfile
+- Gemfile.lock
+- Guardfile
 

--- a/_scss/styles.scss
+++ b/_scss/styles.scss
@@ -1,9 +1,13 @@
 body {
   width: 500px;
-  margin: 0 auto; }
+  margin: 0 auto;
+}
 
 .forkme {
   position: absolute;
   top: 0;
   right: 0;
-  border: 0; }
+  border: 0;
+}
+
+

--- a/js/app.js
+++ b/js/app.js
@@ -1,3 +1,6 @@
-$(document).ready(function() {
-  console.log("page ready");
-});
+(function() {
+  $(function() {
+    return console.log("page ready");
+  });
+
+}).call(this);


### PR DESCRIPTION
This implements issue #3 

It works well here on my machine but I'd love a quick code review. The new instructions in the README explain how to use it. It should handle compilation of the coffeescript and sass assets but _also_ the jekyll building and serving. If it does that for you and seems useful, let me know and I'll merge it :pig2:

![screen shot 2013-11-01 at 7 16 08 pm](https://f.cloud.github.com/assets/1421211/1457853/a63185c0-434b-11e3-8dbf-9d399ec3262d.png)
